### PR TITLE
Update base Docker image version to be v0.11.10

### DIFF
--- a/fmt/Dockerfile
+++ b/fmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.8
+FROM hashicorp/terraform:0.11.10
 
 LABEL "com.github.actions.name"="terraform fmt"
 LABEL "com.github.actions.description"="Validate terraform files are formatted"

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.8
+FROM hashicorp/terraform:0.11.10
 
 LABEL "com.github.actions.name"="terraform init"
 LABEL "com.github.actions.description"="Run terraform init"

--- a/plan/Dockerfile
+++ b/plan/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.8
+FROM hashicorp/terraform:0.11.10
 
 LABEL "com.github.actions.name"="terraform plan"
 LABEL "com.github.actions.description"="Run terraform plan"

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.8
+FROM hashicorp/terraform:0.11.10
 
 LABEL "com.github.actions.name"="terraform validate"
 LABEL "com.github.actions.description"="Validate the terraform files in a directory"


### PR DESCRIPTION
This is needed as users may have statefiles that have been applied using
the latest terraform version but are seeing failures when running the
Github Actions.

Fixes #2

Here is the `terraform init` failure message that I'm seeing from the actions:

```
Already have image (with digest): gcr.io/github-actions-development/action-runner:latest
Initializing modules...
- module.network
  Getting source "../../modules/example/"
- module.example.example

Initializing the backend...

Successfully configured the backend "s3"! Terraform will automatically
use this backend unless the backend configuration changes.

Error: 
Terraform doesn't allow running any operations against a state
that was written by a future Terraform version. The state is
reporting it is written by Terraform '0.11.10'

Please run at least that version of Terraform to continue.

### FAILED terraform-init 13:31:48Z (32.568s)
```