### PR TITLE
Make comments more verbose by adding Workflow and Action names

### DIFF
--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -30,7 +30,7 @@ $FILE_DIFF
 "
 done
 
-COMMENT="#### \`terraform fmt\` Failed
+COMMENT="#### ${GITHUB_WORKFLOW} - ${GITHUB_ACTION}:\`terraform fmt\` Failed
 $FMT_OUTPUT
 "
 PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')

--- a/init/entrypoint.sh
+++ b/init/entrypoint.sh
@@ -16,7 +16,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
     exit $SUCCESS
 fi
 
-COMMENT="#### \`terraform init\` Failed
+COMMENT="#### ${GITHUB_WORKFLOW} - ${GITHUB_ACTION}: \`terraform init\` Failed
 \`\`\`
 $OUTPUT
 \`\`\`"

--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -43,7 +43,7 @@ fi
 COMMENT=""
 if [ $SUCCESS -ne 0 ]; then
     OUTPUT=$(wrap "$OUTPUT")
-    COMMENT="#### \`terraform plan\` Failed
+    COMMENT="#### ${GITHUB_WORKFLOW} - ${GITHUB_ACTION}: \`terraform plan\` Failed
 $OUTPUT"
 else
     # Remove "Refreshing state..." lines by only keeping output after the
@@ -60,7 +60,7 @@ else
     # Call wrap to optionally wrap our output in a collapsible markdown section.
     OUTPUT=$(wrap "$OUTPUT")
 
-    COMMENT="#### \`terraform plan\` Success
+    COMMENT="#### ${GITHUB_WORKFLOW} - ${GITHUB_ACTION}: \`terraform plan\` Success
 $OUTPUT"
 fi
 

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -19,7 +19,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
     exit $SUCCESS
 fi
 
-COMMENT="#### \`terraform validate\` Failed
+COMMENT="#### ${GITHUB_WORKFLOW} - ${GITHUB_ACTION}: \`terraform validate\` Failed
 \`\`\`
 $OUTPUT
 \`\`\`"


### PR DESCRIPTION
## Case
When you run identical actions on multiple directories, the comments that are created in the PR can't be easily traced back. For instance, I have a Terraform module with 2 example plans, and as part of my CI I want to run `terraform plan` on both. However, for both steps the comment in the PR is exactly the same.

## Solution
I have added the Workflow and Action names (that are available in the environment anyway) to the contents of `$COMMENT`. See the image below (top is original, bottom is as implemented in this PR):

![image](https://user-images.githubusercontent.com/10847042/54752981-278fbe00-4be0-11e9-9a44-b8bd1fd8bdc0.png)
