### PR TITLE
Add Terraform Enterprise support

### DIFF
--- a/init/entrypoint.sh
+++ b/init/entrypoint.sh
@@ -2,6 +2,14 @@
 set -e
 cd "${TF_ACTION_WORKING_DIR:-.}"
 
+if [[ ! -z "$TF_ACTION_TFE_TOKEN" ]]; then
+  cat > ~/.terraformrc << EOF
+credentials "${TF_ACTION_TFE_HOSTNAME:-app.terraform.io}" {
+  token = "$TF_ACTION_TFE_TOKEN"
+}
+EOF
+fi
+
 set +e
 OUTPUT=$(sh -c "terraform init -no-color -input=false $*" 2>&1)
 SUCCESS=$?

--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -26,8 +26,17 @@ set -e
 
 cd "${TF_ACTION_WORKING_DIR:-.}"
 
-WORKSPACE=${TF_ACTION_WORKSPACE:-default}
-terraform workspace select "$WORKSPACE"
+if [[ ! -z "$TF_ACTION_TFE_TOKEN" ]]; then
+  cat > ~/.terraformrc << EOF
+credentials "${TF_ACTION_TFE_HOSTNAME:-app.terraform.io}" {
+  token = "$TF_ACTION_TFE_TOKEN"
+}
+EOF
+fi
+
+if [[ ! -z "$TF_ACTION_WORKSPACE" ]] && [[ "$TF_ACTION_WORKSPACE" != "default" ]]; then
+  terraform workspace select "$TF_ACTION_WORKSPACE"
+fi
 
 set +e
 OUTPUT=$(sh -c "TF_IN_AUTOMATION=true terraform plan -no-color -input=false $*" 2>&1)

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -2,8 +2,9 @@
 set -e
 cd "${TF_ACTION_WORKING_DIR:-.}"
 
-WORKSPACE=${TF_ACTION_WORKSPACE:-default}
-terraform workspace select "$WORKSPACE"
+if [[ ! -z "$TF_ACTION_WORKSPACE" ]] && [[ "$TF_ACTION_WORKSPACE" != "default" ]]; then
+  terraform workspace select "$TF_ACTION_WORKSPACE"
+fi
 
 set +e
 OUTPUT=$(sh -c "terraform validate -no-color $*" 2>&1)


### PR DESCRIPTION
- New TF_ACTION_TFE_TOKEN environment variable for specifying the
terraform enteprise token.
- New TF_ACTION_TFE_HOSTNAME environment variable for specifying the
hostname of your TFE installation. Defaults to app.terraform.io
- Don't use workspace select unless workspace is not equal to
"default". We need to do this because the remote backend doesn't support
calling workspace select "default".

Fixes #9 