### PR TITLE
Add action and workflow names to output

### DIFF
--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -32,6 +32,7 @@ done
 
 COMMENT="#### \`terraform fmt\` Failed
 $FMT_OUTPUT
+*Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*
 "
 PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
 COMMENTS_URL=$(cat /github/workflow/event.json | jq -r .pull_request.comments_url)

--- a/init/entrypoint.sh
+++ b/init/entrypoint.sh
@@ -28,7 +28,8 @@ fi
 COMMENT="#### \`terraform init\` Failed
 \`\`\`
 $OUTPUT
-\`\`\`"
+\`\`\`
+*Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
 PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
 COMMENTS_URL=$(cat /github/workflow/event.json | jq -r .pull_request.comments_url)
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null

--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -53,7 +53,8 @@ COMMENT=""
 if [ $SUCCESS -ne 0 ]; then
     OUTPUT=$(wrap "$OUTPUT")
     COMMENT="#### \`terraform plan\` Failed
-$OUTPUT"
+$OUTPUT
+*Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
 else
     # Remove "Refreshing state..." lines by only keeping output after the
     # delimiter (72 dashes) that represents the end of the refresh stage.
@@ -70,7 +71,8 @@ else
     OUTPUT=$(wrap "$OUTPUT")
 
     COMMENT="#### \`terraform plan\` Success
-$OUTPUT"
+$OUTPUT
+*Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
 fi
 
 # Post the comment.

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -23,7 +23,8 @@ fi
 COMMENT="#### \`terraform validate\` Failed
 \`\`\`
 $OUTPUT
-\`\`\`"
+\`\`\`
+*Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
 PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
 COMMENTS_URL=$(cat /github/workflow/event.json | jq -r .pull_request.comments_url)
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null


### PR DESCRIPTION
Adds
*Workflow: `<workflow name>`, Action: `<action name>`*

To comments so users with multiple actions/workflows can trace back the comments.

![image](https://user-images.githubusercontent.com/1034429/56384815-cd404800-61f3-11e9-8f89-a1f0c74aeeed.png)


Closes #13