### PR TITLE
Adds support for terraform v0.12.0

### DIFF
--- a/fmt/Dockerfile
+++ b/fmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.13
+FROM hashicorp/terraform:0.12.0
 
 LABEL "com.github.actions.name"="terraform fmt"
 LABEL "com.github.actions.description"="Validate terraform files are formatted"
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq
+RUN apk --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -3,9 +3,9 @@ set -e
 cd "${TF_ACTION_WORKING_DIR:-.}"
 
 set +e
-UNFMT_FILES=$(sh -c "terraform fmt -check=true -write=false $*" 2>&1)
+OUTPUT=$(sh -c "terraform fmt -no-color -check -list -recursive $*" 2>&1)
 SUCCESS=$?
-echo "$UNFMT_FILES"
+echo "$OUTPUT"
 set -e
 
 if [ $SUCCESS -eq 0 ]; then
@@ -16,11 +16,22 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
     exit $SUCCESS
 fi
 
-# Iterate through each unformatted file and build up a comment.
-FMT_OUTPUT=""
-for file in $UNFMT_FILES; do
-FILE_DIFF=$(terraform fmt -write=false -diff=true "$file" | sed -n '/@@.*/,//{/@@.*/d;p}')
-FMT_OUTPUT="$FMT_OUTPUT
+if [ $SUCCESS -eq 2 ]; then
+    # If it exits with 2, then there was a parse error and the command won't have
+    # printed out the files that have failed. In this case we comment back with the
+    # whole parse error.
+    COMMENT="\`\`\`
+$OUTPUT
+\`\`\`
+"
+else
+    # Otherwise the output will contain a list of unformatted filenames.
+    # Iterate through each file and build up a comment containing the diff
+    # of each file.
+    COMMENT=""
+    for file in $OUTPUT; do
+        FILE_DIFF=$(terraform fmt -no-color -write=false -diff "$file" | sed -n '/@@.*/,//{/@@.*/d;p}')
+        COMMENT="$COMMENT
 <details><summary><code>$file</code></summary>
 
 \`\`\`diff
@@ -28,15 +39,15 @@ $FILE_DIFF
 \`\`\`
 </details>
 "
-done
+    done
+fi
 
-COMMENT="#### \`terraform fmt\` Failed
-$FMT_OUTPUT
+COMMENT_WRAPPER="#### \`terraform fmt\` Failed
+$COMMENT
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*
 "
-PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
+PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT_WRAPPER" '.body = $body')
 COMMENTS_URL=$(cat /github/workflow/event.json | jq -r .pull_request.comments_url)
 curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
 
 exit $SUCCESS
-

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.13
+FROM hashicorp/terraform:0.12.0
 
 LABEL "com.github.actions.name"="terraform init"
 LABEL "com.github.actions.description"="Run terraform init"
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq
+RUN apk --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/plan/Dockerfile
+++ b/plan/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.13
+FROM hashicorp/terraform:0.12.0
 
 LABEL "com.github.actions.name"="terraform plan"
 LABEL "com.github.actions.description"="Run terraform plan"
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq
+RUN apk --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.13
+FROM hashicorp/terraform:0.12.0
 
 LABEL "com.github.actions.name"="terraform validate"
 LABEL "com.github.actions.description"="Validate the terraform files in a directory"
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq
+RUN apk --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Take Andrew's PR (#20) and add a fix for the new flags to `fmt` in 0.12.
Also fixes a bug that was there previously where if `fmt` failed due to validation errors we would print a malformed comment.