### PR TITLE
Update Docker images to Terraform 0.12.3

### DIFF
--- a/apply/Dockerfile
+++ b/apply/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.2
+FROM hashicorp/terraform:0.12.3
 
 LABEL "com.github.actions.name"="terraform apply"
 LABEL "com.github.actions.description"="Run Terraform Apply"

--- a/fmt/Dockerfile
+++ b/fmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.2
+FROM hashicorp/terraform:0.12.3
 
 LABEL "com.github.actions.name"="terraform fmt"
 LABEL "com.github.actions.description"="Validate terraform files are formatted"

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.2
+FROM hashicorp/terraform:0.12.3
 
 LABEL "com.github.actions.name"="terraform init"
 LABEL "com.github.actions.description"="Run terraform init"

--- a/plan/Dockerfile
+++ b/plan/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.2
+FROM hashicorp/terraform:0.12.3
 
 LABEL "com.github.actions.name"="terraform plan"
 LABEL "com.github.actions.description"="Run terraform plan"

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.12.2
+FROM hashicorp/terraform:0.12.3
 
 LABEL "com.github.actions.name"="terraform validate"
 LABEL "com.github.actions.description"="Validate the terraform files in a directory"


### PR DESCRIPTION
This PR bumps the Docker base images to those built for Terraform 0.12.3.

Just a question: shouldn't we use `FROM hashicorp/terraform:latest` instead?
Since all Terraform files touched with a newer version can't be validated with an earlier version, having an old version in these actions means that CI breaks whenever any developer upgrades Terraform.