### PR TITLE
Do Not Try to Comment on Non-PR Builds (fixes #50)

### DIFF
--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -18,27 +18,28 @@ if [ $SUCCESS -eq 0 ]; then
     exit 0
 fi
 
-if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
-    exit $SUCCESS
-fi
+if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
+    if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
+        exit $SUCCESS
+    fi
 
-OUTPUT=$(stripcolors "$OUTPUT")
-if [ $SUCCESS -eq 2 ]; then
-    # If it exits with 2, then there was a parse error and the command won't have
-    # printed out the files that have failed. In this case we comment back with the
-    # whole parse error.
-    COMMENT="\`\`\`
+    OUTPUT=$(stripcolors "$OUTPUT")
+    if [ $SUCCESS -eq 2 ]; then
+        # If it exits with 2, then there was a parse error and the command won't have
+        # printed out the files that have failed. In this case we comment back with the
+        # whole parse error.
+        COMMENT="\`\`\`
 $OUTPUT
 \`\`\`
 "
-else
-    # Otherwise the output will contain a list of unformatted filenames.
-    # Iterate through each file and build up a comment containing the diff
-    # of each file.
-    COMMENT=""
-    for file in $OUTPUT; do
-        FILE_DIFF=$(terraform fmt -no-color -write=false -diff "$file" | sed -n '/@@.*/,//{/@@.*/d;p}')
-        COMMENT="$COMMENT
+    else
+        # Otherwise the output will contain a list of unformatted filenames.
+        # Iterate through each file and build up a comment containing the diff
+        # of each file.
+        COMMENT=""
+        for file in $OUTPUT; do
+            FILE_DIFF=$(terraform fmt -no-color -write=false -diff "$file" | sed -n '/@@.*/,//{/@@.*/d;p}')
+            COMMENT="$COMMENT
 <details><summary><code>$file</code></summary>
 
 \`\`\`diff
@@ -46,15 +47,16 @@ $FILE_DIFF
 \`\`\`
 </details>
 "
-    done
-fi
+        done
+    fi
 
-COMMENT_WRAPPER="#### \`terraform fmt\` Failed
+    COMMENT_WRAPPER="#### \`terraform fmt\` Failed
 $COMMENT
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*
 "
-PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT_WRAPPER" '.body = $body')
-COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
-curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
+    PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT_WRAPPER" '.body = $body')
+    COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
+    curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
+fi
 
 exit $SUCCESS

--- a/init/entrypoint.sh
+++ b/init/entrypoint.sh
@@ -27,19 +27,21 @@ if [ $SUCCESS -eq 0 ]; then
     exit 0
 fi
 
-if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
-    exit $SUCCESS
-fi
+if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
+    if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
+        exit $SUCCESS
+    fi
 
-OUTPUT=$(stripcolors "$OUTPUT")
-COMMENT="#### \`terraform init\` Failed
+    OUTPUT=$(stripcolors "$OUTPUT")
+    COMMENT="#### \`terraform init\` Failed
 \`\`\`
 $OUTPUT
 \`\`\`
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
-PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
-COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
-curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
+    PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
+    COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
+    curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
+fi
 
 exit $SUCCESS
 

--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -83,9 +83,11 @@ $OUTPUT
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
 fi
 
-# Post the comment.
-PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
-COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
-curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
+if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
+    # Post the comment.
+    PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
+    COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
+    curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
+fi
 
 exit $SUCCESS

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -22,18 +22,20 @@ if [ $SUCCESS -eq 0 ]; then
     exit 0
 fi
 
-if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
-    exit $SUCCESS
-fi
+if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
+    if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
+        exit $SUCCESS
+    fi
 
-OUTPUT=$(stripcolors "$OUTPUT")
-COMMENT="#### \`terraform validate\` Failed
+    OUTPUT=$(stripcolors "$OUTPUT")
+    COMMENT="#### \`terraform validate\` Failed
 \`\`\`
 $OUTPUT
 \`\`\`
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
-PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
-COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
-curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
+    PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
+    COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
+    curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
+fi
 
 exit $SUCCESS


### PR DESCRIPTION
In the event of a non-PR workflow, the actions would still attempt to
post output to the non-existent PR URL. This change checks to see if jq
parsed a "null" URL, and doesn't run curl if that is the case.