### PR TITLE
Add Bash to each Terraform command action

### DIFF
--- a/apply/Dockerfile
+++ b/apply/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --no-cache add jq curl bash
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/fmt/Dockerfile
+++ b/fmt/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --no-cache add jq curl bash
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --no-cache add jq curl bash
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/plan/Dockerfile
+++ b/plan/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --no-cache add jq curl bash
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --no-cache add jq curl bash
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Addresses #48 by adding Bash to each Terraform command's docker image for compatibility with Plans that rely on Bash scripting, ergo Bash is not added to the filter action.

 