### PR TITLE
Ensure upgrades of curl dependencies

### DIFF
--- a/apply/Dockerfile
+++ b/apply/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --upgrade --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/fmt/Dockerfile
+++ b/fmt/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --upgrade --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --upgrade --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/plan/Dockerfile
+++ b/plan/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --upgrade --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/hashicorp/terraform-github-actions"
 LABEL "homepage"="http://github.com/hashicorp/terraform-github-actions"
 LABEL "maintainer"="HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-RUN apk --no-cache add jq curl
+RUN apk --upgrade --no-cache add jq curl
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Solution to errors seen in actions which include curl:
`Error relocating /usr/bin/curl: curl_multi_poll: symbol not found`
`##[error]Docker run failed with exit code 127`