### PR TITLE
Enable output coloring for logs

### DIFF
--- a/apply/entrypoint.sh
+++ b/apply/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# stripcolors takes some output and removes ANSI color codes.
+stripcolors() {
+  echo "$1" | sed 's/\x1b\[[0-9;]*m//g'
+}
+
 # wrap takes some output and wraps it in a collapsible markdown section if
 # it's over $TF_ACTION_WRAP_LINES long.
 wrap() {
@@ -39,7 +44,7 @@ if [[ ! -z "$TF_ACTION_WORKSPACE" ]] && [[ "$TF_ACTION_WORKSPACE" != "default" ]
 fi
 
 set +e
-OUTPUT=$(sh -c "TF_IN_AUTOMATION=true terraform apply -no-color -auto-approve -input=false $*" 2>&1)
+OUTPUT=$(sh -c "TF_IN_AUTOMATION=true terraform apply -auto-approve -input=false $*" 2>&1)
 SUCCESS=$?
 echo "$OUTPUT"
 set -e
@@ -52,6 +57,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ] || [ "$P
 fi
 
 # Build the comment we'll post to the PR.
+OUTPUT=$(stripcolors "$OUTPUT")
 COMMENT=""
 if [ $SUCCESS -ne 0 ]; then
     OUTPUT=$(wrap "$OUTPUT")

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
+
+# stripcolors takes some output and removes ANSI color codes.
+stripcolors() {
+  echo "$1" | sed 's/\x1b\[[0-9;]*m//g'
+}
+
 set -e
 cd "${TF_ACTION_WORKING_DIR:-.}"
 
 set +e
-OUTPUT=$(sh -c "terraform fmt -no-color -check -list -recursive $*" 2>&1)
+OUTPUT=$(sh -c "terraform fmt -check -list -recursive $*" 2>&1)
 SUCCESS=$?
 echo "$OUTPUT"
 set -e
@@ -16,6 +22,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
     exit $SUCCESS
 fi
 
+OUTPUT=$(stripcolors "$OUTPUT")
 if [ $SUCCESS -eq 2 ]; then
     # If it exits with 2, then there was a parse error and the command won't have
     # printed out the files that have failed. In this case we comment back with the

--- a/init/entrypoint.sh
+++ b/init/entrypoint.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# stripcolors takes some output and removes ANSI color codes.
+stripcolors() {
+  echo "$1" | sed 's/\x1b\[[0-9;]*m//g'
+}
+
 set -e
 cd "${TF_ACTION_WORKING_DIR:-.}"
 
@@ -12,7 +18,7 @@ fi
 
 set +e
 export TF_APPEND_USER_AGENT="terraform-github-actions/1.0"
-OUTPUT=$(sh -c "terraform init -no-color -input=false $*" 2>&1)
+OUTPUT=$(sh -c "terraform init -input=false $*" 2>&1)
 SUCCESS=$?
 echo "$OUTPUT"
 set -e
@@ -25,6 +31,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
     exit $SUCCESS
 fi
 
+OUTPUT=$(stripcolors "$OUTPUT")
 COMMENT="#### \`terraform init\` Failed
 \`\`\`
 $OUTPUT

--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# stripcolors takes some output and removes ANSI color codes.
+stripcolors() {
+  echo "$1" | sed 's/\x1b\[[0-9;]*m//g'
+}
+
 # wrap takes some output and wraps it in a collapsible markdown section if
 # it's over $TF_ACTION_WRAP_LINES long.
 wrap() {
@@ -39,7 +44,7 @@ if [[ ! -z "$TF_ACTION_WORKSPACE" ]] && [[ "$TF_ACTION_WORKSPACE" != "default" ]
 fi
 
 set +e
-OUTPUT=$(sh -c "TF_IN_AUTOMATION=true terraform plan -no-color -input=false $*" 2>&1)
+OUTPUT=$(sh -c "TF_IN_AUTOMATION=true terraform plan -input=false $*" 2>&1)
 SUCCESS=$?
 echo "$OUTPUT"
 set -e
@@ -49,6 +54,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
 fi
 
 # Build the comment we'll post to the PR.
+OUTPUT=$(stripcolors "$OUTPUT")
 COMMENT=""
 if [ $SUCCESS -ne 0 ]; then
     OUTPUT=$(wrap "$OUTPUT")

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# stripcolors takes some output and removes ANSI color codes.
+stripcolors() {
+  echo "$1" | sed 's/\x1b\[[0-9;]*m//g'
+}
+
 set -e
 cd "${TF_ACTION_WORKING_DIR:-.}"
 
@@ -7,7 +13,7 @@ if [[ ! -z "$TF_ACTION_WORKSPACE" ]] && [[ "$TF_ACTION_WORKSPACE" != "default" ]
 fi
 
 set +e
-OUTPUT=$(sh -c "terraform validate -no-color $*" 2>&1)
+OUTPUT=$(sh -c "terraform validate $*" 2>&1)
 SUCCESS=$?
 echo "$OUTPUT"
 set -e
@@ -20,6 +26,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
     exit $SUCCESS
 fi
 
+OUTPUT=$(stripcolors "$OUTPUT")
 COMMENT="#### \`terraform validate\` Failed
 \`\`\`
 $OUTPUT


### PR DESCRIPTION
Enable colors to add some flair to the action logs. To keep comments sane, we strip the ANSI color codes before posting.

This is mainly in response to the conclusion of #55. While the coloring isn't as helpful as Github's diff syntax coloring. It's better than nothing when looking at action output logs.
