### PR TITLE
Set action output with comment body

### DIFF
--- a/apply/action.yml
+++ b/apply/action.yml
@@ -1,0 +1,11 @@
+name: 'Terraform Apply Action'
+description: 'Runs terraform apply and comments back on the pull request with the apply output.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+branding:
+  icon: 'play-circle'
+  color: 'purple'
+outputs:
+  comment:
+    description: 'The comment content'

--- a/apply/entrypoint.sh
+++ b/apply/entrypoint.sh
@@ -82,4 +82,5 @@ $OUTPUT
     curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
 fi
 
+echo ::set-output name=comment::"$COMMENT"
 exit $SUCCESS

--- a/fmt/action.yml
+++ b/fmt/action.yml
@@ -1,0 +1,11 @@
+name: 'Terraform Fmt Action'
+description: 'Runs terraform fmt to validate all Terraform files in a directory are in the canonical format. If any files differ, this action will comment back on the pull request with the diffs of each file.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+branding:
+  icon: 'terminal'
+  color: 'purple'
+outputs:
+  comment:
+    description: 'The comment content'

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -59,4 +59,5 @@ $COMMENT
     curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
 fi
 
+echo ::set-output name=comment::"$COMMENT"
 exit $SUCCESS

--- a/init/action.yml
+++ b/init/action.yml
@@ -1,0 +1,11 @@
+name: 'Terraform Init Action'
+description: 'Runs terraform init to initialize a Terraform working directory. This action will comment back on the pull request on failure.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+branding:
+  icon: 'download'
+  color: 'purple'
+outputs:
+  comment:
+    description: 'The comment content'

--- a/init/entrypoint.sh
+++ b/init/entrypoint.sh
@@ -43,5 +43,6 @@ $OUTPUT
     curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
 fi
 
+echo ::set-output name=comment::"$COMMENT"
 exit $SUCCESS
 

--- a/plan/action.yml
+++ b/plan/action.yml
@@ -1,0 +1,11 @@
+name: 'Terraform Plan Action'
+description: 'Runs terraform plan and comments back on the pull request with the plan output.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+branding:
+  icon: 'book-open'
+  color: 'purple'
+outputs:
+  comment:
+    description: 'The comment content'

--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -101,4 +101,5 @@ if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
     curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
 fi
 
+echo ::set-output name=comment::"$COMMENT"
 exit $SUCCESS

--- a/validate/action.yml
+++ b/validate/action.yml
@@ -1,0 +1,11 @@
+name: 'Terraform Validate Action'
+description: 'Runs terraform validate to validate the terraform files in a directory.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+branding:
+  icon: 'alert-triangle'
+  color: 'purple'
+outputs:
+  comment:
+    description: 'The comment content'

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -38,4 +38,5 @@ $OUTPUT
     curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL" > /dev/null
 fi
 
+echo ::set-output name=comment::"$COMMENT"
 exit $SUCCESS


### PR DESCRIPTION
GitHub Actions have the ability to set outputs so that steps in the same
GHA job can retrieve data from previous actions:

https://help.github.com/en/articles/development-tools-for-github-actions#set-an-output-parameter-set-output

These outputs will be available via:
```
${{ steps.*.outputs.comment }}
```

This PR also adds the `action.yml` for defining the metadata of an
action, so that outputs may be exported:
https://help.github.com/en/articles/metadata-syntax-for-github-actions#outputs

This is just a convenient way for consumers to be able to interact with
the results of a particular terraform action. For example, someone might
want to take the comment and post it to their Slack, or perhaps they
want to do some grepping over the output to check for certain resources
being created, etc.