### PR TITLE
Append working directory to action output

### DIFF
--- a/apply/entrypoint.sh
+++ b/apply/entrypoint.sh
@@ -55,14 +55,14 @@ fi
 COMMENT=""
 if [ $SUCCESS -ne 0 ]; then
     OUTPUT=$(wrap "$OUTPUT")
-    COMMENT="#### \`terraform apply\` Failed
+    COMMENT="#### \`terraform apply\` Failed for \`$TF_ACTION_WORKING_DIRECTORY\`
 $OUTPUT
 
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
 else
     # Call wrap to optionally wrap our output in a collapsible markdown section.
     OUTPUT=$(wrap "$OUTPUT")
-    COMMENT="#### \`terraform apply\` Success
+    COMMENT="#### \`terraform apply\` Success for \`$TF_ACTION_WORKING_DIRECTORY\`
 $OUTPUT
 
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"

--- a/fmt/entrypoint.sh
+++ b/fmt/entrypoint.sh
@@ -42,7 +42,7 @@ $FILE_DIFF
     done
 fi
 
-COMMENT_WRAPPER="#### \`terraform fmt\` Failed
+COMMENT_WRAPPER="#### \`terraform fmt\` Failed for \`$TF_ACTION_WORKING_DIRECTORY\`
 $COMMENT
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*
 "

--- a/init/entrypoint.sh
+++ b/init/entrypoint.sh
@@ -25,7 +25,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
     exit $SUCCESS
 fi
 
-COMMENT="#### \`terraform init\` Failed
+COMMENT="#### \`terraform init\` Failed for \`$TF_ACTION_WORKING_DIRECTORY\`
 \`\`\`
 $OUTPUT
 \`\`\`

--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -52,7 +52,7 @@ fi
 COMMENT=""
 if [ $SUCCESS -ne 0 ]; then
     OUTPUT=$(wrap "$OUTPUT")
-    COMMENT="#### \`terraform plan\` Failed
+    COMMENT="#### \`terraform plan\` Failed for \`$TF_ACTION_WORKING_DIRECTORY\`
 $OUTPUT
 
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
@@ -71,7 +71,7 @@ else
     # Call wrap to optionally wrap our output in a collapsible markdown section.
     OUTPUT=$(wrap "$OUTPUT")
 
-    COMMENT="#### \`terraform plan\` Success
+    COMMENT="#### \`terraform plan\` Success for \`$TF_ACTION_WORKING_DIRECTORY\`
 $OUTPUT
 
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -20,7 +20,7 @@ if [ "$TF_ACTION_COMMENT" = "1" ] || [ "$TF_ACTION_COMMENT" = "false" ]; then
     exit $SUCCESS
 fi
 
-COMMENT="#### \`terraform validate\` Failed
+COMMENT="#### \`terraform validate\` Failed for \`$TF_ACTION_WORKING_DIRECTORY\`
 \`\`\`
 $OUTPUT
 \`\`\`


### PR DESCRIPTION
We've added the `$TF_ACTION_WORKING_DIRECTORY` to the output for the
action comments, so that we can differentiate between actions that get
applied to multiple directories in the same PR.

Fixes #41
Fixes #66