### PR TITLE
Add flag to skip commenting if there are no changes

### DIFF
--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -94,7 +94,7 @@ $OUTPUT
 *Workflow: \`$GITHUB_WORKFLOW\`, Action: \`$GITHUB_ACTION\`*"
 fi
 
-if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
+if [[ "$GITHUB_EVENT_NAME" == 'pull_request' && ( "$CHANGES_PRESENT" = true && "$TF_SKIP_COMMENT_IF_NO_CHANGES" = false )]]; then
     # Post the comment.
     PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
     COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)


### PR DESCRIPTION
Adds a variable: `$TF_SKIP_COMMENT_IF_NO_CHANGES`

If this variable is not true or unset, which is the default case, then
we'll always post the terraform output back to the PR, regardless of if
there are changes or if the terraform plan succeeded or failed. We'll
always post.

This change relies on terraform's -detailed-exitcode functionality:
https://www.terraform.io/docs/commands/plan.html#detailed-exitcode

Fixes hashicorp#29