### PR TITLE
Create workspace on the fly using plan

### DIFF
--- a/plan/README.md
+++ b/plan/README.md
@@ -5,5 +5,20 @@ Runs `terraform plan` and comments back on the pull request with the plan output
 
 If `TF_WORKSPACE_FORCE_CREATE` is set to true when plan is executed and the given workspace doesn't exist the `plan` command will create it for you.
 
+# Example
+
+```
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set branch name as workspace
+      run: echo ::set-env name=TF_ACTION_WORKSPACE::${GITHUB_REF##*/}
+    - uses: hashicorp/terraform-github-actions/init@v0.4.6
+    - uses: hashicorp/terraform-github-actions/plan@v<current_version>
+      env:
+       TF_WORKSPACE_FORCE_CREATE: true
+```
 
 See [https://www.terraform.io/docs/github-actions/actions/plan.html](https://www.terraform.io/docs/github-actions/actions/plan.html).

--- a/plan/README.md
+++ b/plan/README.md
@@ -1,4 +1,9 @@
 # Terraform Plan Action
 Runs `terraform plan` and comments back on the pull request with the plan output.
 
+# Env Variables
+
+If `TF_WORKSPACE_FORCE_CREATE` is set to true when plan is executed and the given workspace doesn't exist the `plan` command will create it for you.
+
+
 See [https://www.terraform.io/docs/github-actions/actions/plan.html](https://www.terraform.io/docs/github-actions/actions/plan.html).

--- a/plan/entrypoint.sh
+++ b/plan/entrypoint.sh
@@ -40,7 +40,7 @@ EOF
 fi
 
 if [[ ! -z "$TF_ACTION_WORKSPACE" ]] && [[ "$TF_ACTION_WORKSPACE" != "default" ]]; then
-  terraform workspace select "$TF_ACTION_WORKSPACE"
+  terraform workspace select "$TF_ACTION_WORKSPACE" || ("$TF_WORKSPACE_FORCE_CREATE" && terraform workspace new "$TF_ACTION_WORKSPACE")
 fi
 
 set +e


### PR DESCRIPTION
Hi Terraform team,
This PR has a single purpose to add a possibility to create a new workspace during the `plan` execution.
I had explained why this is helpful for me on this issue ( #81 ).

Running without the `TF_WORKSPACE_FORCE_CREATE`
![Screenshot from 2019-10-19 11-24-31](https://user-images.githubusercontent.com/5270832/67146591-146eca80-f263-11e9-83fd-7424382c1ad8.png)

Running with the `TF_WORKSPACE_FORCE_CREATE=true`
![Screenshot from 2019-10-19 11-26-57](https://user-images.githubusercontent.com/5270832/67146628-6879af00-f263-11e9-903a-e3b1e2c850a6.png)
