### PR TITLE
Pass comments through pipes instead of as command line arguments

### DIFF
--- a/src/terraform_apply.sh
+++ b/src/terraform_apply.sh
@@ -34,10 +34,10 @@ ${applyOutput}
 
     applyCommentWrapper=$(stripColors "${applyCommentWrapper}")
     echo "apply: info: creating JSON"
-    applyPayload=$(echo '{}' | jq --arg body "${applyCommentWrapper}" '.body = $body')
+    applyPayload=$(echo "${applyCommentWrapper}" | jq -R --slurp '{body: .}')
     applyCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
     echo "apply: info: commenting on the pull request"
-    curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data "${applyPayload}" "${applyCommentsURL}" > /dev/null
+    echo "${applyPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${applyCommentsURL}" > /dev/null
   fi
 
   exit ${applyExitCode}

--- a/src/terraform_fmt.sh
+++ b/src/terraform_fmt.sh
@@ -11,7 +11,7 @@ function terraformFmt {
   echo "fmt: info: checking if Terraform files in ${tfWorkingDir} are correctly formatted"
   fmtOutput=$(terraform fmt -check=true -write=false -diff ${fmtRecursive} 2>&1)
   fmtExitCode=${?}
-  
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${fmtExitCode} -eq 0 ]; then
     echo "fmt: info: Terraform files in ${tfWorkingDir} are correctly formatted"
@@ -60,10 +60,10 @@ ${fmtComment}
 
     fmtCommentWrapper=$(stripColors "${fmtCommentWrapper}")
     echo "fmt: info: creating JSON"
-    fmtPayload=$(echo '{}' | jq --arg body "${fmtCommentWrapper}" '.body = $body')
+    fmtPayload=$(echo "${fmtCommentWrapper}" | jq -R --slurp '{body: .}')
     fmtCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
     echo "fmt: info: commenting on the pull request"
-    curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data "${fmtPayload}" "${fmtCommentsURL}" > /dev/null
+    echo "${fmtPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${fmtCommentsURL}" > /dev/null
   fi
 
   exit ${fmtExitCode}

--- a/src/terraform_init.sh
+++ b/src/terraform_init.sh
@@ -5,7 +5,7 @@ function terraformInit {
   echo "init: info: initializing Terraform configuration in ${tfWorkingDir}"
   initOutput=$(terraform init -input=false 2>&1)
   initExitCode=${?}
-  
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${initExitCode} -eq 0 ]; then
     echo "init: info: successfully initialized Terraform configuration in ${tfWorkingDir}"
@@ -31,10 +31,10 @@ ${initOutput}
 
     initCommentWrapper=$(stripColors "${initCommentWrapper}")
     echo "init: info: creating JSON"
-    initPayload=$(echo '{}' | jq --arg body "${initCommentWrapper}" '.body = $body')
+    initPayload=$(echo "${initCommentWrapper}" | jq -R --slurp '{body: .}')
     initCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
     echo "init: info: commenting on the pull request"
-    curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data "${initPayload}" "${initCommentsURL}" > /dev/null
+    echo "${initPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${initCommentsURL}" > /dev/null
   fi
 
   exit ${initExitCode}

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -29,6 +29,9 @@ function terraformPlan {
         planOutput=$(echo "${planOutput}" | sed -n -r '/-{72}/,/-{72}/{ /-{72}/d; p }')
     fi
     planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
+
+     # If output is longer than max length (65536 characters), keep last part
+    planOutput=$(echo "${planOutput}" | tail -c 65000 )
   fi
 
   # Exit code of !0 indicates failure.

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -40,7 +40,7 @@ function terraformPlan {
 
   # Comment on the pull request if necessary.
   if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "${tfComment}" == "1" ] && ([ "${planHasChanges}" == "true" ] || [ "${planCommentStatus}" == "Failed" ]); then
-    planCommentWrapper="#### \`terraform plan\` ${planCommentStatus} 
+    planCommentWrapper="#### \`terraform plan\` ${planCommentStatus}
 <details><summary>Show Output</summary>
 
 \`\`\`
@@ -53,10 +53,10 @@ ${planOutput}
 
     planCommentWrapper=$(stripColors "${planCommentWrapper}")
     echo "plan: info: creating JSON"
-    planPayload=$(echo '{}' | jq --arg body "${planCommentWrapper}" '.body = $body')
+    planPayload=$(echo "${planCommentWrapper}" | jq -R --slurp '{body: .}')
     planCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
     echo "plan: info: commenting on the pull request"
-    curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data "${planPayload}" "${planCommentsURL}" > /dev/null
+    echo "${planPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${planCommentsURL}" > /dev/null
   fi
 
   echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}

--- a/src/terraform_validate.sh
+++ b/src/terraform_validate.sh
@@ -5,7 +5,7 @@ function terraformValidate {
   echo "validate: info: validating Terraform configuration in ${tfWorkingDir}"
   validateOutput=$(terraform validate 2>&1)
   validateExitCode=${?}
-  
+
   # Exit code of 0 indicates success. Print the output and exit.
   if [ ${validateExitCode} -eq 0 ]; then
     echo "validate: info: successfully validated Terraform configuration in ${tfWorkingDir}"
@@ -31,10 +31,10 @@ ${validateOutput}
 
     validateCommentWrapper=$(stripColors "${validateCommentWrapper}")
     echo "validate: info: creating JSON"
-    validatePayload=$(echo '{}' | jq --arg body "${validateCommentWrapper}" '.body = $body')
+    validatePayload=$(echo "${validateCommentWrapper}" | jq -R --slurp '{body: .}')
     validateCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
     echo "validate: info: commenting on the pull request"
-    curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data "${validatePayload}" "${validateCommentsURL}" > /dev/null
+    echo "${validatePayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${validateCommentsURL}" > /dev/null
   fi
 
   exit ${validateExitCode}


### PR DESCRIPTION
This makes the commenting much more reliable when the plan output is hundreds of lines long. 

Without this I would just get
```
/entrypoint.sh: line 99: jq: Argument list too long
```

But with this change it works as it should.

I also made it cut the error output if it is too long. This can happen when it failed to fetch the status of some resource.