### PR TITLE
Do not use -recursive option for Terraform 0.11.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.1
+
+### Fixed
+
+* Do not use `-recursive` option with `terraform fmt` for Terraform 0.11.x. ([#90](https://github.com/hashicorp/terraform-github-actions/issues/90))
+
 ## v0.5.0
 
 ### Added
@@ -9,10 +15,6 @@
 ### Changed
 
 * Completely refactored the codebase into one GitHub Action. Please refer to the README for current usage.
-
-### Deprecated
-
-N/A
 
 ### Removed
 
@@ -25,7 +27,3 @@ N/A
 * Added support for Terraform 0.11.14. ([#42](https://github.com/hashicorp/terraform-github-actions/issues/67))
 * Comments will not be posted to pull requests when `terraform plan` contains no changes. ([#29](https://github.com/hashicorp/terraform-github-actions/issues/67))
 * Added ability to specify a Terraform version to use. ([#23](https://github.com/hashicorp/terraform-github-actions/issues/67))
-
-### Security
-
-N/A

--- a/src/main.sh
+++ b/src/main.sh
@@ -4,6 +4,17 @@ function stripColors {
   echo "${1}" | sed 's/\x1b\[[0-9;]*m//g'
 }
 
+function hasPrefix {
+  case ${2} in
+    "${1}"*)
+      true
+      ;;
+    *)
+      false
+      ;;
+  esac
+}
+
 function parseInputs {
   # Required inputs
   if [ "${INPUT_TF_ACTIONS_VERSION}" != "" ]; then

--- a/src/terraform_fmt.sh
+++ b/src/terraform_fmt.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
 function terraformFmt {
+  # Eliminate `-recursive` option for Terraform 0.11.x.
+  fmtRecursive="-recursive"
+  if hasPrefix "0.11" "${tfVersion}"; then
+    fmtRecursive=""
+  fi
+
   # Gather the output of `terraform fmt`.
   echo "fmt: info: checking if Terraform files in ${tfWorkingDir} are correctly formatted"
-  fmtOutput=$(terraform fmt -check -write=false -diff -recursive 2>&1)
+  fmtOutput=$(terraform fmt -check -write=false -diff ${fmtRecursive} 2>&1)
   fmtExitCode=${?}
   
   # Exit code of 0 indicates success. Print the output and exit.


### PR DESCRIPTION
This is more of a band-aid than a proper solution. It's probably worth just eliminating `-recursive` altogether but this will do for now.

Fixes #90.

