### PR TITLE
Supports args when specifying subcommands

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -75,26 +75,30 @@ function main {
   parseInputs
   cd ${GITHUB_WORKSPACE}/${tfWorkingDir}
 
-  case "${tfSubcommand}" in
+  cmdargs=(${tfSubcommand})
+  cmd=${cmdargs[0]}
+  args=${cmdargs[@]:1}
+
+  case "${cmd}" in
     fmt)
       installTerraform
-      terraformFmt
+      terraformFmt $args
       ;;
     init)
       installTerraform
-      terraformInit
+      terraformInit $args
       ;;
     validate)
       installTerraform
-      terraformValidate
+      terraformValidate $args
       ;;
     plan)
       installTerraform
-      terraformPlan
+      terraformPlan $args
       ;;
     apply)
       installTerraform
-      terraformApply
+      terraformApply $args
       ;;
     *)
       echo "Error: Must provide a valid value for terraform_subcommand"

--- a/src/terraform_apply.sh
+++ b/src/terraform_apply.sh
@@ -3,7 +3,7 @@
 function terraformApply {
   # Gather the output of `terraform apply`.
   echo "apply: info: applying Terraform configuration in ${tfWorkingDir}"
-  applyOutput=$(terraform apply -auto-approve -input=false 2>&1)
+  applyOutput=$(terraform apply ${1} -auto-approve -input=false 2>&1)
   applyExitCode=${?}
   applyCommentStatus="Failed"
 

--- a/src/terraform_fmt.sh
+++ b/src/terraform_fmt.sh
@@ -9,7 +9,7 @@ function terraformFmt {
 
   # Gather the output of `terraform fmt`.
   echo "fmt: info: checking if Terraform files in ${tfWorkingDir} are correctly formatted"
-  fmtOutput=$(terraform fmt -check=true -write=false -diff ${fmtRecursive} 2>&1)
+  fmtOutput=$(terraform fmt ${1} -check=true -write=false -diff ${fmtRecursive} 2>&1)
   fmtExitCode=${?}
   
   # Exit code of 0 indicates success. Print the output and exit.

--- a/src/terraform_init.sh
+++ b/src/terraform_init.sh
@@ -3,7 +3,7 @@
 function terraformInit {
   # Gather the output of `terraform init`.
   echo "init: info: initializing Terraform configuration in ${tfWorkingDir}"
-  initOutput=$(terraform init -input=false 2>&1)
+  initOutput=$(terraform init ${1} -input=false 2>&1)
   initExitCode=${?}
   
   # Exit code of 0 indicates success. Print the output and exit.

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -3,7 +3,7 @@
 function terraformPlan {
   # Gather the output of `terraform plan`.
   echo "plan: info: planning Terraform configuration in ${tfWorkingDir}"
-  planOutput=$(terraform plan -detailed-exitcode -input=false 2>&1)
+  planOutput=$(terraform plan ${1} -detailed-exitcode -input=false 2>&1)
   planExitCode=${?}
   planHasChanges=false
   planCommentStatus="Failed"


### PR DESCRIPTION
This allows `tf_actions_subcommand: 'plan -lock=false'` and other arguments.

The current workaround is to use `TF_ARGS` / `TF_ARGS_name`.