### PR TITLE
Fixing improper handling of arguments

### DIFF
--- a/src/terraform_apply.sh
+++ b/src/terraform_apply.sh
@@ -3,7 +3,7 @@
 function terraformApply {
   # Gather the output of `terraform apply`.
   echo "apply: info: applying Terraform configuration in ${tfWorkingDir}"
-  applyOutput=$(terraform apply -auto-approve -input=false "${*}" 2>&1)
+  applyOutput=$(terraform apply -auto-approve -input=false ${*} 2>&1)
   applyExitCode=${?}
   applyCommentStatus="Failed"
 

--- a/src/terraform_fmt.sh
+++ b/src/terraform_fmt.sh
@@ -9,7 +9,7 @@ function terraformFmt {
 
   # Gather the output of `terraform fmt`.
   echo "fmt: info: checking if Terraform files in ${tfWorkingDir} are correctly formatted"
-  fmtOutput=$(terraform fmt -check=true -write=false -diff ${fmtRecursive} "${*}" 2>&1)
+  fmtOutput=$(terraform fmt -check=true -write=false -diff ${fmtRecursive} ${*} 2>&1)
   fmtExitCode=${?}
 
   # Exit code of 0 indicates success. Print the output and exit.

--- a/src/terraform_init.sh
+++ b/src/terraform_init.sh
@@ -3,7 +3,7 @@
 function terraformInit {
   # Gather the output of `terraform init`.
   echo "init: info: initializing Terraform configuration in ${tfWorkingDir}"
-  initOutput=$(terraform init -input=false "${*}" 2>&1)
+  initOutput=$(terraform init -input=false ${*} 2>&1)
   initExitCode=${?}
 
   # Exit code of 0 indicates success. Print the output and exit.

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -3,7 +3,7 @@
 function terraformPlan {
   # Gather the output of `terraform plan`.
   echo "plan: info: planning Terraform configuration in ${tfWorkingDir}"
-  planOutput=$(terraform plan -detailed-exitcode -input=false "${*}" 2>&1)
+  planOutput=$(terraform plan -detailed-exitcode -input=false ${*} 2>&1)
   planExitCode=${?}
   planHasChanges=false
   planCommentStatus="Failed"

--- a/src/terraform_validate.sh
+++ b/src/terraform_validate.sh
@@ -3,7 +3,7 @@
 function terraformValidate {
   # Gather the ouput of `terraform validate`.
   echo "validate: info: validating Terraform configuration in ${tfWorkingDir}"
-  validateOutput=$(terraform validate "${*}" 2>&1)
+  validateOutput=$(terraform validate ${*} 2>&1)
   validateExitCode=${?}
 
   # Exit code of 0 indicates success. Print the output and exit.


### PR DESCRIPTION
When `${*}` is quoted and does not contain any value, an empty string will be used instead. This causes some `terraform` commands to operate on an empty directory, not the current working directory.