### PR TITLE
Fix output collapse

### DIFF
--- a/src/terraform_output.sh
+++ b/src/terraform_output.sh
@@ -11,7 +11,13 @@ function terraformOutput {
     echo "output: info: successfully gathered all the outputs for the Terraform configuration in ${tfWorkingDir}"
     echo "${outputOutput}"
     echo
-    echo ::set-output name=tf_actions_output::${outputOutput}
+
+    # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
+    outputOutput="${outputOutput//'%'/'%25'}"
+    outputOutput="${outputOutput//$'\n'/'%0A'}"
+    outputOutput="${outputOutput//$'\r'/'%0D'}"
+
+    echo "::set-output name=tf_actions_output::${outputOutput}"
     exit ${outputExitCode}
   fi
 


### PR DESCRIPTION
When output is multi-line string, the `tf_actions_output` in `output` subcommand collapses. It is because output is not quoted in `src/terraform_output.sh`. And according to the discussion below, escape is required before `set-output`.
https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870