### PR TITLE
Let plan action output the plan-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Outputs are used to pass information to subsequent GitHub Actions steps.
 
 * `tf_actions_output` - The Terraform outputs in JSON format.
 * `tf_actions_plan_has_changes` - Whether or not the Terraform plan contained changes.
+* `tf_actions_plan_output` - The Terraform plan output.
 
 ## Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,8 @@ outputs:
     description: 'The Terraform outputs in JSON format.'
   tf_actions_plan_has_changes:
     description: 'Whether or not the Terraform plan contained changes.'
+  tf_actions_plan_output:
+    description: 'The Terraform plan output.'
 runs:
   using: 'docker'
   image: './Dockerfile'

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -63,5 +63,6 @@ ${planOutput}
   fi
 
   echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
+  echo ::set-output name=tf_actions_plan_output::${planOutput}
   exit ${planExitCode}
 }

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -63,6 +63,12 @@ ${planOutput}
   fi
 
   echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
-  echo ::set-output name=tf_actions_plan_output::${planOutput}
+
+  # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
+  planOutput="${planOutput//'%'/'%25'}"
+  planOutput="${planOutput//$'\n'/'%0A'}"
+  planOutput="${planOutput//$'\r'/'%0D'}"
+
+  echo "::set-output name=tf_actions_plan_output::${planOutput}"
   exit ${planExitCode}
 }


### PR DESCRIPTION
Subsequent actions may want to us the `terraform plan` output, e.g. sending it as email, posting to Slack, etc.

This PR sets this output as `tf_actions_plan_output` from the action