### PR TITLE
Support to use the latest version of Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This was a simplified example showing the basic features of these Terraform GitH
 Inputs configure Terraform GitHub Actions to perform different actions.
 
 * `tf_actions_subcommand` - (Required) The Terraform subcommand to execute. Valid values are `fmt`, `init`, `validate`, `plan`, and `apply`.
-* `tf_actions_version` - (Required) The Terraform version to install and execute.
+* `tf_actions_version` - (Required) The Terraform version to install and execute. If set to `latest`, the latest stable version will be used.
 * `tf_actions_cli_credentials_hostname` - (Optional) Hostname for the CLI credentials file. Defaults to `app.terraform.io`.
 * `tf_actions_cli_credentials_token` - (Optional) Token for the CLI credentials file.
 * `tf_actions_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `true`.

--- a/src/main.sh
+++ b/src/main.sh
@@ -64,6 +64,11 @@ EOF
 }
 
 function installTerraform {
+  if [[ "${tfVersion}" == "latest" ]]; then
+    echo "Checking the latest version of Terraform"
+    tfVersion=$(curl -s https://releases.hashicorp.com/terraform/ | grep -o "terraform_[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[^-]" | grep -m 1 -o "[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*")
+  fi
+
   url="https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"
 
   echo "Downloading Terraform v${tfVersion}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -66,7 +66,7 @@ EOF
 function installTerraform {
   if [[ "${tfVersion}" == "latest" ]]; then
     echo "Checking the latest version of Terraform"
-    tfVersion=$(curl -s https://releases.hashicorp.com/terraform/ | grep -o "terraform_[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[^-]" | grep -m 1 -o "[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*")
+    tfVersion=$(curl -sL https://releases.hashicorp.com/terraform/index.json | jq -r '.versions[].version' | grep -v '[-].*' | sort -rV | head -n 1)
   fi
 
   url="https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"

--- a/src/main.sh
+++ b/src/main.sh
@@ -67,6 +67,11 @@ function installTerraform {
   if [[ "${tfVersion}" == "latest" ]]; then
     echo "Checking the latest version of Terraform"
     tfVersion=$(curl -sL https://releases.hashicorp.com/terraform/index.json | jq -r '.versions[].version' | grep -v '[-].*' | sort -rV | head -n 1)
+
+    if [[ -z "${tfVersion}" ]]; then
+      echo "Failed to fetch the latest version"
+      exit 1
+    fi
   fi
 
   url="https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"


### PR DESCRIPTION
Automatically download the latest version when `tf_actions_version` set to `latest`.

refs: #94 