### PR TITLE
remove mkdir from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM alpine:3
 
 RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]
 
-RUN ["bin/sh", "-c", "mkdir -p /src"]
-
 COPY ["src", "/src/"]
 
 ENTRYPOINT ["/src/main.sh"]


### PR DESCRIPTION
`mkdir` is not necessary in Dockerfile.

You can simply use WORKDIR but in case you just copy from src to /src, so it can be ommited.

Additionally, as alpine uses sh by default, I don't think you have to speficy /bin/sh in RUN, too.

```Dockerfile
FROM alpine:3 

RUN apk add --update --no-cache bash ca-certificates curl git jq openssh

COPY src /src

ENTRYPOINT ["/src/main.sh"]
```