### PR TITLE
Adding terraform taint actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An exit code of `0` is considered a successful execution.
 
 ## Usage
 
-The most common workflow is to run `terraform fmt`, `terraform init`, `terraform validate`, and `terraform plan` on all of the Terraform files in the root of the repository when a pull request is opened or updated. A comment will be posted to the pull request depending on the output of the Terraform subcommand being executed. This workflow can be configured by adding the following content to the GitHub Actions workflow YAML file.
+The most common workflow is to run `terraform fmt`, `terraform init`, `terraform validate`, `terraform plan`, and `terraform taint` on all of the Terraform files in the root of the repository when a pull request is opened or updated. A comment will be posted to the pull request depending on the output of the Terraform subcommand being executed. This workflow can be configured by adding the following content to the GitHub Actions workflow YAML file.
 
 ```yaml
 name: 'Terraform GitHub Actions'

--- a/examples/tainting.md
+++ b/examples/tainting.md
@@ -1,0 +1,39 @@
+# Terraform Tainting
+
+Resources to taint can be specified using the `args` with option
+
+```yaml
+name: 'Terraform GitHub Actions'
+on:
+  - pull_request
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+      - name: 'Terraform Init'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'init'
+          tf_actions_working_dir: '.'
+          tf_actions_comment: true
+        env:
+          TF_WORKSPACE: dev
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Terraform Taint'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'taint'
+          tf_actions_working_dir: '.'
+          tf_actions_comment: true
+          args: 'aws_instance.host'
+        env:
+          TF_WORKSPACE: dev
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Multiple resources can be specified by separating with spaces: `args: 'aws_instance.host1 aws_instance.host2'`

--- a/examples/tainting.md
+++ b/examples/tainting.md
@@ -1,6 +1,6 @@
 # Terraform Tainting
 
-Resources to taint can be specified using the `args` with option
+Resources to taint can be specified using the `args` with option.
 
 ```yaml
 name: 'Terraform GitHub Actions'

--- a/examples/tainting.md
+++ b/examples/tainting.md
@@ -36,4 +36,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-Multiple resources can be specified by separating with spaces: `args: 'aws_instance.host1 aws_instance.host2'`
+Multiple resources can be specified by separating with spaces: `args: 'aws_instance.host1 aws_instance.host2'`.

--- a/src/main.sh
+++ b/src/main.sh
@@ -102,6 +102,7 @@ function main {
   source ${scriptDir}/terraform_plan.sh
   source ${scriptDir}/terraform_apply.sh
   source ${scriptDir}/terraform_output.sh
+  source ${scriptDir}/terraform_taint.sh
 
   parseInputs
   configureCLICredentials
@@ -131,6 +132,10 @@ function main {
     output)
       installTerraform
       terraformOutput ${*}
+      ;;
+    taint)
+      installTerraform
+      terraformTaint ${*}
       ;;
     *)
       echo "Error: Must provide a valid value for terraform_subcommand"

--- a/src/terraform_taint.sh
+++ b/src/terraform_taint.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+function terraformTaint {
+  # Gather the output of `terraform taint`.
+  echo "taint: info: tainting Terraform configuration in ${tfWorkingDir}"
+  #taintOutput=$(terraform taint ${*} 2>&1)
+  taintOutput=$(for resource in ${*}; do terraform taint -allow-missing $resource; done 2>&1)
+  taintExitCode=${?}
+  taintCommentStatus="Failed"
+
+  # Exit code of 0 indicates success with no changes. Print the output and exit.
+  if [ ${taintExitCode} -eq 0 ]; then
+    taintCommentStatus="Success"
+    echo "taint: info: successfully tainted Terraform configuration in ${tfWorkingDir}"
+    echo "${taintOutput}"
+    echo
+    exit ${taintExitCode}
+  fi
+
+  # Exit code of !0 indicates failure.
+  if [ ${taintExitCode} -ne 0 ]; then
+    echo "taint: error: failed to taint Terraform configuration in ${tfWorkingDir}"
+    echo "${taintOutput}"
+    echo
+  fi
+
+  # Comment on the pull request if necessary.
+  if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "${tfComment}" == "1" ]; then
+    taintCommentWrapper="#### \`terraform taint\` ${taintCommentStatus}
+<details><summary>Show Output</summary>
+
+\`\`\`
+${taintOutput}
+\`\`\`
+
+</details>
+
+*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`*"
+
+    taintCommentWrapper=$(stripColors "${taintCommentWrapper}")
+    echo "taint: info: creating JSON"
+    taintPayload=$(echo "${taintCommentWrapper}" | jq -R --slurp '{body: .}')
+    taintCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
+    echo "taint: info: commenting on the pull request"
+    echo "${taintPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${taintCommentsURL}" > /dev/null
+  fi
+
+  exit ${taintExitCode}
+}


### PR DESCRIPTION
I found the need to be able to run `terraform taint` in a workflow. 

It takes a space-delimited list in the `args` option in the `with` block. Additionally `terraform taint` runs with the `-allow-missing` flag.