### PR TITLE
Ensure output is executed when no changes present

### DIFF
--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -13,7 +13,6 @@ function terraformPlan {
     echo "plan: info: successfully planned Terraform configuration in ${tfWorkingDir}"
     echo "${planOutput}"
     echo
-    exit ${planExitCode}
   fi
 
   # Exit code of 2 indicates success with changes. Print the output, change the


### PR DESCRIPTION
This should fix #135 . This will use the `exit` at the end of the function instead of exiting early.