### PR TITLE
Add support for Git credential.helper via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Outputs are used to pass information to subsequent GitHub Actions steps.
 Secrets are similar to inputs except that they are encrypted and only used by GitHub Actions. It's a convenient way to keep sensitive data out of the GitHub Actions workflow YAML file.
 
 * `GITHUB_TOKEN` - (Optional) The GitHub API token used to post comments to pull requests. Not required if the `tf_actions_comment` input is set to `false`.
+* `GH_USER` - (Optional) The GitHub username that Terraform will be using for cloning private repositories.
+* `GH_PASS` - (Optional) A personal access token that can be used for [authenticating via HTTPS on the command line](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#using-a-token-on-the-command-line).
 
 Other secrets may be needed to authenticate with Terraform backends and providers.
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -69,9 +69,18 @@ function configureGitCredentials {
 https://${GH_USER}:${GH_PASS}@github.com/
 EOF
 
+    currRules=$(git config --global --get-all "url.https://github.com/.insteadOf")
     git config --global credential.helper store
-    git config --global "url.https://github.com/.insteadOf" "ssh://git@github.com/"
-    git config --global --add "url.https://github.com/.insteadOf" "git@github.com:"
+
+    sshRule="ssh://git@github.com/"
+    if [[ $currRules != *"$sshRule"* ]]; then
+      git config --global --add "url.https://github.com/.insteadOf" "$sshRule"
+    fi
+
+    gitRule="git@github.com:"
+    if [[ $currRules != *"$gitRule"* ]]; then
+      git config --global --add "url.https://github.com/.insteadOf" "$gitRule"
+    fi
   fi
 }
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -63,6 +63,18 @@ EOF
   fi
 }
 
+function configureGitCredentials {
+  if [[ ! -z "${GH_USER}" ]] && [[ ! -z "${GH_PASS}" ]]; then
+    cat > ${HOME}/.git-credentials << EOF
+https://${GH_USER}:${GH_PASS}@github.com/
+EOF
+
+    git config --global credential.helper store
+    git config --global "url.https://github.com/.insteadOf" "ssh://git@github.com/"
+    git config --global --add "url.https://github.com/.insteadOf" "git@github.com:"
+  fi
+}
+
 function installTerraform {
   if [[ "${tfVersion}" == "latest" ]]; then
     echo "Checking the latest version of Terraform"
@@ -105,6 +117,7 @@ function main {
 
   parseInputs
   configureCLICredentials
+  configureGitCredentials
   cd ${GITHUB_WORKSPACE}/${tfWorkingDir}
 
   case "${tfSubcommand}" in


### PR DESCRIPTION
This PR introduces two new environment variables to this action: `GH_USER` and `GH_PASS`. The are prefixed with `GH_` to show they're GitHub related however they're not named `GITHUB_` to prevent conflicts with [default GitHub Actions environment variables](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables). These credentials are used for [authenticating over HTTPS](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#using-a-token-on-the-command-line) by saving them to the [`git credential-store`](https://git-scm.com/docs/git-credential-store#FILES); the git configuration is then modified to ["rewrite" SSH and Git URLs to use the HTTPS version via `insteadOf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) so any private modules can be authenticated over HTTPS.

Potentially fixes #120