### PR TITLE
Adding terraform destroy actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This was a simplified example showing the basic features of these Terraform GitH
 
 Inputs configure Terraform GitHub Actions to perform different actions.
 
-* `tf_actions_subcommand` - (Required) The Terraform subcommand to execute. Valid values are `fmt`, `init`, `validate`, `plan`, `apply` and `destroy`.
+* `tf_actions_subcommand` - (Required) The Terraform subcommand to execute. Valid values are `fmt`, `init`, `validate`, `plan`, `apply` and  `destroy`.
 * `tf_actions_version` - (Required) The Terraform version to install and execute. If set to `latest`, the latest stable version will be used.
 * `tf_actions_cli_credentials_hostname` - (Optional) Hostname for the CLI credentials file. Defaults to `app.terraform.io`.
 * `tf_actions_cli_credentials_token` - (Optional) Token for the CLI credentials file.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This was a simplified example showing the basic features of these Terraform GitH
 
 Inputs configure Terraform GitHub Actions to perform different actions.
 
-* `tf_actions_subcommand` - (Required) The Terraform subcommand to execute. Valid values are `fmt`, `init`, `validate`, `plan`, and `apply`.
+* `tf_actions_subcommand` - (Required) The Terraform subcommand to execute. Valid values are `fmt`, `init`, `validate`, `plan`, `apply` and `destroy`.
 * `tf_actions_version` - (Required) The Terraform version to install and execute. If set to `latest`, the latest stable version will be used.
 * `tf_actions_cli_credentials_hostname` - (Optional) Hostname for the CLI credentials file. Defaults to `app.terraform.io`.
 * `tf_actions_cli_credentials_token` - (Optional) Token for the CLI credentials file.

--- a/src/main.sh
+++ b/src/main.sh
@@ -101,6 +101,7 @@ function main {
   source ${scriptDir}/terraform_validate.sh
   source ${scriptDir}/terraform_plan.sh
   source ${scriptDir}/terraform_apply.sh
+  source ${scriptDir}/terraform_destroy.sh
   source ${scriptDir}/terraform_output.sh
   source ${scriptDir}/terraform_import.sh
   source ${scriptDir}/terraform_taint.sh
@@ -129,6 +130,10 @@ function main {
     apply)
       installTerraform
       terraformApply ${*}
+      ;;
+    destroy)
+      installTerraform
+      terraformDestroy ${*}
       ;;
     output)
       installTerraform

--- a/src/main.sh
+++ b/src/main.sh
@@ -155,3 +155,4 @@ function main {
 }
 
 main "${*}"
+ 

--- a/src/terraform_destroy.sh
+++ b/src/terraform_destroy.sh
@@ -46,4 +46,3 @@ ${destroyOutput}
   exit ${destroyExitCode}
 }
 
-

--- a/src/terraform_destroy.sh
+++ b/src/terraform_destroy.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+function terraformdestroy {
+  # Gather the output of `terraform destroy`.
+  echo "destroy: info: destroying Terraform configuration in ${tfWorkingDir}"
+  destroyOutput=$(terraform destroy -auto-approve -input=false ${*} 2>&1)
+  destroyExitCode=${?}
+  destroyCommentStatus="Failed"
+
+  # Exit code of 0 indicates success. Print the output and exit.
+  if [ ${destroyExitCode} -eq 0 ]; then
+    echo "destroy: info: successfully applied Terraform configuration in ${tfWorkingDir}"
+    echo "${destroyOutput}"
+    echo
+    destroyCommentStatus="Success"
+  fi
+
+  # Exit code of !0 indicates failure.
+  if [ ${destroyExitCode} -ne 0 ]; then
+    echo "destroy: error: failed to destroy Terraform configuration in ${tfWorkingDir}"
+    echo "${destroyOutput}"
+    echo
+  fi
+
+  # Comment on the pull request if necessary.
+  if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "${tfComment}" == "1" ]; then
+    destroyCommentWrapper="#### \`terraform destroy\` ${destroyCommentStatus}
+<details><summary>Show Output</summary>
+
+\`\`\`
+${destroyOutput}
+\`\`\`
+
+</details>
+
+*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`*"
+
+    destroyCommentWrapper=$(stripColors "${destroyCommentWrapper}")
+    echo "destroy: info: creating JSON"
+    destroyPayload=$(echo "${destroyCommentWrapper}" | jq -R --slurp '{body: .}')
+    destroyCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
+    echo "destroy: info: commenting on the pull request"
+    echo "${destroyPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${destroyCommentsURL}" > /dev/null
+  fi
+
+  exit ${destroyExitCode}
+}
+
+

--- a/src/terraform_destroy.sh
+++ b/src/terraform_destroy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function terraformdestroy {
+function terraformDestroy {
   # Gather the output of `terraform destroy`.
   echo "destroy: info: destroying Terraform configuration in ${tfWorkingDir}"
   destroyOutput=$(terraform destroy -auto-approve -input=false ${*} 2>&1)


### PR DESCRIPTION
Destroying created infrastructure is crucial for terraform usage. Therefore, I have included a section in your github action terraform to have the ability to spin down created infrastructure. [Here](https://github.com/iamtito/DevOps/runs/477642602?check_suite_focus=true)
![terraform_github_action](https://user-images.githubusercontent.com/11051621/75637239-31dd7900-5bf3-11ea-9301-c8ad52bd0b90.png)
