### PR TITLE
Save plan to file (allows viewing un-truncated plan as an artifact)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Outputs are used to pass information to subsequent GitHub Actions steps.
 
 * `tf_actions_output` - The Terraform outputs in (stringified) JSON format.
 * `tf_actions_plan_has_changes` - `'true'` if the Terraform plan contained changes, otherwise `'false'`.
-* `tf_actions_plan_output` - The Terraform plan output.
+* `tf_actions_plan_output` - The Terraform plan output (truncated to 64K).
+* `tf_actions_plan_output_file` - File containing the full Terraform plan output (NOT a tfplan file).
 * `tf_actions_fmt_written` - Whether or not the Terraform formatting from `fmt` was written to source files.
 
 ## Secrets

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,9 @@ outputs:
   tf_actions_plan_has_changes:
     description: 'Whether or not the Terraform plan contained changes.'
   tf_actions_plan_output:
-    description: 'The Terraform plan output.'
+    description: 'The Terraform plan output (may be truncated).'
+  tf_actions_plan_output_file:
+    description: 'Path to file containing the full plan output.'
   tf_actions_fmt_written:
     description: 'Whether or not the Terraform formatting was written to source files.'
 runs:

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -9,6 +9,7 @@ function terraformPlan {
   planCommentStatus="Failed"
   planOutputFile="${tfWorkingDir}/plan.txt"
   touch "${planOutputFile}"
+  echo "::set-output name=tf_actions_plan_output_file::${planOutputFile}"
 
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${planExitCode} -eq 0 ]; then
@@ -35,7 +36,6 @@ function terraformPlan {
 
     # Save full plan output to a file so it can optionally be added as an artifact
     echo "${planOutput}" > "${planOutputFile}"
-    echo "::set-output name=tf_actions_plan_output_file::${planOutputFile}"
 
      # If output is longer than max length (65536 characters), keep last part
     planOutput=$(echo "${planOutput}" | tail -c 65000 )

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -31,6 +31,11 @@ function terraformPlan {
     fi
     planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
 
+    # Save plan output to a file so it can optionally be added as an artifact (long plans are truncated)
+    planOutputFile=plan.txt
+    echo "${planOutput}" > "${planOutputFile}"
+    echo "::set-output name=tf_actions_plan_output_file::${planOutputFile}"
+
      # If output is longer than max length (65536 characters), keep last part
     planOutput=$(echo "${planOutput}" | tail -c 65000 )
   fi

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -7,6 +7,8 @@ function terraformPlan {
   planExitCode=${?}
   planHasChanges=false
   planCommentStatus="Failed"
+  planOutputFile="${tfWorkingDir}/plan.txt"
+  touch "${planOutputFile}"
 
   # Exit code of 0 indicates success with no changes. Print the output and exit.
   if [ ${planExitCode} -eq 0 ]; then
@@ -32,7 +34,6 @@ function terraformPlan {
     planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
 
     # Save full plan output to a file so it can optionally be added as an artifact
-    planOutputFile="${tfWorkingDir}/plan.txt"
     echo "${planOutput}" > "${planOutputFile}"
     echo "::set-output name=tf_actions_plan_output_file::${planOutputFile}"
 

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -31,8 +31,8 @@ function terraformPlan {
     fi
     planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
 
-    # Save plan output to a file so it can optionally be added as an artifact (long plans are truncated)
-    planOutputFile=plan.txt
+    # Save full plan output to a file so it can optionally be added as an artifact
+    planOutputFile="${tfWorkingDir}/plan.txt"
     echo "${planOutput}" > "${planOutputFile}"
     echo "::set-output name=tf_actions_plan_output_file::${planOutputFile}"
 


### PR DESCRIPTION
**Change**

Save the plan text output to a file in the current tfWorkingDir and set a new output to the full path to the plan file (`tf_actions_plan_output_file`)

There is an existing output variable `tf_actions_plan_output` but this contains the truncated plan (and would not be able to hold the full plan anyway).

**Use Case**

Our plans are almost always huge due to use of AWS Elastic Beanstalk. Even a change in a single property dumps the entire property set and we have many EB environments in a single workspace.  The plan is frequently truncated to 64K making the comment back to the PR not always as helpful for a review.

The solution I'm using for this is to capture the plan as an artifact to the job where it can be easily reviewed as opposed to crawling the job logs.

**Sample Artifact Use**

```yaml
      - name: Upload Plan Artifact
        uses: actions/upload-artifact@v1
        with:
          name: terraform-plan-output
          path: ${{ steps.terraform-plan.outputs.tf_actions_plan_output_file }}
```

**Testing**
Tested using a fork of this repo and verified that the full plan is produced in the file and that the file can be archived as an arrtifact