### PR TITLE
Allow creating dynamic workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This was a simplified example showing the basic features of these Terraform GitH
 
 Inputs configure Terraform GitHub Actions to perform different actions.
 
-* `tf_actions_subcommand` - (Required) The Terraform subcommand to execute. Valid values are `fmt`, `init`, `validate`, `plan`, and `apply`.
+* `tf_actions_subcommand` - (Required) The Terraform subcommand to execute. Valid values are `fmt`, `init`, `validate`, `plan`, `apply`, and `destroy`.
 * `tf_actions_version` - (Required) The Terraform version to install and execute. If set to `latest`, the latest stable version will be used.
 * `tf_actions_cli_credentials_hostname` - (Optional) Hostname for the CLI credentials file. Defaults to `app.terraform.io`.
 * `tf_actions_cli_credentials_token` - (Optional) Token for the CLI credentials file.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Inputs configure Terraform GitHub Actions to perform different actions.
 * `tf_actions_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `true`.
 * `tf_actions_working_dir` - (Optional) The working directory to change into before executing Terraform subcommands. Defaults to `.` which means use the root of the GitHub repository.
 * `tf_actions_fmt_write` - (Optional) Whether or not to write `fmt` changes to source files. Defaults to `false`.
+* `tf_actions_init_create_workspace` - (Optional) Whether or not to automatically create the specified workspace during `init`. See the dedicated section for more info. Defaults to `false`.
+
+### `tf_actions_init_create_workspace`
+
+If set to `true`, your `terraform init` step will first run the following extra steps:
+
+1. Run `terraform init` for the "default" workspace (with any custom `args` specified)
+2. Check the requested workspace exists and create it if not.
+
+Then, initialization with your requested workspace will proceed as per usual.
+
+Specify your target workspace with the [`TF_WORKSPACE` environment variable](#environment-variables).
+
 
 ## Outputs
 

--- a/examples/workspaces.md
+++ b/examples/workspaces.md
@@ -20,9 +20,14 @@ jobs:
           tf_actions_subcommand: 'init'
           tf_actions_working_dir: '.'
           tf_actions_comment: true
+          tf_actions_init_create_workspace: true # optional
         env:
           TF_WORKSPACE: dev
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 If using the `remote` backend with the `name` argument, the configured workspace will be created for you. If using the `remote` backend with the `prefix` argument, the configured workspace must already exist and will not be created for you.
+
+## `tf_actions_init_create_workspace`
+
+If this is set to `true`, the workspace will be automatically created if required during the `terraform init` step. This is useful if you are dynamically loading the workspace name based on eg the branch name or similar.

--- a/src/main.sh
+++ b/src/main.sh
@@ -20,14 +20,14 @@ function parseInputs {
   if [ "${INPUT_TF_ACTIONS_VERSION}" != "" ]; then
     tfVersion=${INPUT_TF_ACTIONS_VERSION}
   else
-    echo "Input terraform_version cannot be empty"
+    echo "Input tf_actions_version cannot be empty"
     exit 1
   fi
 
   if [ "${INPUT_TF_ACTIONS_SUBCOMMAND}" != "" ]; then
     tfSubcommand=${INPUT_TF_ACTIONS_SUBCOMMAND}
   else
-    echo "Input terraform_subcommand cannot be empty"
+    echo "Input tf_actions_subcommand cannot be empty"
     exit 1
   fi
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -61,6 +61,15 @@ function parseInputs {
   if [ -n "${TF_WORKSPACE}" ]; then
     tfWorkspace="${TF_WORKSPACE}"
   fi
+
+  tfInitCreateWorkspace="0"
+  if [ "${INPUT_TF_ACTIONS_INIT_CREATE_WORKSPACE}" == "1" ] || [ "${INPUT_TF_ACTIONS_INIT_CREATE_WORKSPACE}" == "true" ]; then
+    tfInitCreateWorkspace=1
+  fi
+  if [ "${tfInitCreateWorkspace}" == "1" ] && [ "${tfSubcommand}" != "init" ]; then
+    echo "You can only specify input 'tf_actions_init_create_workspace' when 'tf_actions_subcommand' is 'init'"
+    exit 1
+  fi
 }
 
 function configureCLICredentials {

--- a/src/main.sh
+++ b/src/main.sh
@@ -106,6 +106,9 @@ function installTerraform {
 function main {
   # Source the other files to gain access to their functions
   scriptDir=$(dirname ${0})
+  # Common functions
+  source ${scriptDir}/send_comment.sh
+  # Actions
   source ${scriptDir}/terraform_fmt.sh
   source ${scriptDir}/terraform_init.sh
   source ${scriptDir}/terraform_validate.sh

--- a/src/send_comment.sh
+++ b/src/send_comment.sh
@@ -15,7 +15,7 @@ ${raw_message}
     return
   fi
 
-  echo "init: info: commenting on the pull request"
+  echo "${GITHUB_ACTION}: info: commenting on pull request"
   local message=$(stripColors "${wrapped_raw_message}")
   local payload=$(echo "${message}" | jq -R --slurp '{body: .}')
   local commentURL=$(jq -r .pull_request.comments_url "${GITHUB_EVENT_PATH}")

--- a/src/send_comment.sh
+++ b/src/send_comment.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Comment on the pull request if necessary.
+function sendPRComment() {
+  local raw_message=$1
+  local wrapped_raw_message="#### \`terraform ${GITHUB_ACTION}\` Failed
+
+\`\`\`
+${raw_message}
+\`\`\`
+
+*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+
+  if [ "$GITHUB_EVENT_NAME" != "pull_request" ] || [ "${tfComment}" != "1" ]; then
+    return
+  fi
+
+  echo "init: info: commenting on the pull request"
+  local message=$(stripColors "${wrapped_raw_message}")
+  local payload=$(echo "${message}" | jq -R --slurp '{body: .}')
+  local commentURL=$(jq -r .pull_request.comments_url "${GITHUB_EVENT_PATH}")
+  echo "${payload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${commentURL}" >/dev/null
+}

--- a/src/terraform_init.sh
+++ b/src/terraform_init.sh
@@ -1,7 +1,42 @@
 #!/bin/bash
 
 function terraformInit {
-  # Gather the output of `terraform init`.
+  # If tf_actions_init_create_workspace is true ("1"), we run init with the
+  # `default` workspace and switch to / create the desired workspace. (This
+  # works around the fact you can't list workspaces from an un-initialized
+  # directory.)
+  if [ ${tfInitCreateWorkspace} == "1" ]; then
+    echo "init: info: pre-initializing Terraform configuration in ${tfWorkingDir}"
+    preInitOutput=$(TF_WORKSPACE=default terraform init -input=false ${*} 2>&1)
+    preInitExitCode=${?}
+
+    if [ ${preInitExitCode} -ne 0 ]; then
+      echo "init: error: failed to pre-init Terraform in ${tfWorkingDir}"
+      echo "${preInitOutput}"
+      # Rewrite tfWorkspace as a hint in the PR comment
+      tfWorkspace="default (for ${tfWorkspace})" sendPRComment "${preInitOutput}"
+      exit 1
+    fi
+
+    # We've initialized, now we should be able to access the list of workspaces
+    workspaces=$(terraform workspace list | cut -c3-)
+    if echo "${workspaces}" | grep -E -q "^${tfWorkspace}$"; then
+      echo "init: info: Terraform workspace '${tfWorkspace}' already exists in ${tfWorkingDir}, not creating it"
+    else
+      echo "init: info: creating Terraform workspace '${tfWorkspace}'"
+      createWorkspaceOutput=$(terraform workspace new "${tfWorkspace}" 2>&1)
+      createWorkspaceExitCode=${?}
+      if [ ${createWorkspaceExitCode} -eq 0 ]; then
+        echo "init: info: successfully created Terraform workspace ${tfWorkspace} in ${tfWorkingDir}"
+      else
+        echo "init: error: failed to create Terraform workspace ${tfWorkspace} in ${tfWorkingDir}"
+        echo "${createWorkspaceOutput}"
+        echo
+        exit ${createWorkspaceExitCode}
+      fi
+    fi
+  fi
+
   echo "init: info: initializing Terraform configuration in ${tfWorkingDir}"
   initOutput=$(terraform init -input=false ${*} 2>&1)
   initExitCode=${?}
@@ -19,23 +54,7 @@ function terraformInit {
   echo "${initOutput}"
   echo
 
-  # Comment on the pull request if necessary.
-  if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "${tfComment}" == "1" ]; then
-    initCommentWrapper="#### \`terraform init\` Failed
-
-\`\`\`
-${initOutput}
-\`\`\`
-
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
-
-    initCommentWrapper=$(stripColors "${initCommentWrapper}")
-    echo "init: info: creating JSON"
-    initPayload=$(echo "${initCommentWrapper}" | jq -R --slurp '{body: .}')
-    initCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
-    echo "init: info: commenting on the pull request"
-    echo "${initPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${initCommentsURL}" > /dev/null
-  fi
+  sendPRComment "${initOutput}"
 
   exit ${initExitCode}
 }


### PR DESCRIPTION
This PR adds one feature:

* Add option `tf_actions_init_create_workspace`. If set to `true`, the `terraform init` action will automatically create the specified workspace if it doesn't already exist

It also makes one architectural change:

* Pull out "send PR comment" into a dedicated function. This change is only made to the `terraformInit` function to keep this PR diff manageable. If it's accepted I'll submit another PR to update remaining actions.

I also included a couple of bonus fixes to existing docs. ✨

Screenshot of this feature working (from a private repository):

<img width="1078" alt="Screen Shot 2020-03-31 at 1 30 37 pm" src="https://user-images.githubusercontent.com/379509/77980965-6bb9b080-7354-11ea-89cc-c78d5ba72709.png">
