### PR TITLE
Show git commit sha in PR comments

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -103,6 +103,18 @@ function installTerraform {
   echo "Successfully unzipped Terraform v${tfVersion}"
 }
 
+# Generate a pretty git commit string.
+# If possible show "$subject ($short_sha)", otherwise "$short_sha". (The former
+# will fail if we are running without a code checkout. For example, in a
+# workflow that only downloads a plan and applies it.)
+function pretty_git_commit() {
+  local message
+  if ! message=$(git log -1 --pretty="%s (%h)" 2>&1); then
+    message="${GITHUB_SHA:0:7}"
+  fi
+  echo "$message"
+}
+
 function main {
   # Source the other files to gain access to their functions
   scriptDir=$(dirname ${0})

--- a/src/terraform_apply.sh
+++ b/src/terraform_apply.sh
@@ -33,7 +33,7 @@ ${applyOutput}
 
 </details>
 
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+*Commit: \`$(pretty_git_commit)\`, Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
 
     applyCommentWrapper=$(stripColors "${applyCommentWrapper}")
     echo "apply: info: creating JSON"

--- a/src/terraform_destroy.sh
+++ b/src/terraform_destroy.sh
@@ -33,7 +33,7 @@ ${destroyOutput}
 
 </details>
 
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`*"
+*Commit: \`$(pretty_git_commit)\`, Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`*"
 
     destroyCommentWrapper=$(stripColors "${destroyCommentWrapper}")
     echo "destroy: info: creating JSON"

--- a/src/terraform_fmt.sh
+++ b/src/terraform_fmt.sh
@@ -56,7 +56,7 @@ ${fmtFileDiff}
     fmtCommentWrapper="#### \`terraform fmt\` Failed
 ${fmtComment}
 
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+*Commit: \`$(pretty_git_commit)\`, Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
 
     fmtCommentWrapper=$(stripColors "${fmtCommentWrapper}")
     echo "fmt: info: creating JSON"

--- a/src/terraform_import.sh
+++ b/src/terraform_import.sh
@@ -33,7 +33,7 @@ ${importOutput}
 
 </details>
 
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+*Commit: \`$(pretty_git_commit)\`, Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
 
     importCommentWrapper=$(stripColors "${importCommentWrapper}")
     echo "import: info: creating JSON"

--- a/src/terraform_init.sh
+++ b/src/terraform_init.sh
@@ -27,7 +27,7 @@ function terraformInit {
 ${initOutput}
 \`\`\`
 
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+*Commit: \`$(pretty_git_commit)\`, Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
 
     initCommentWrapper=$(stripColors "${initCommentWrapper}")
     echo "init: info: creating JSON"

--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -53,7 +53,7 @@ ${planOutput}
 
 </details>
 
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+*Commit: \`$(pretty_git_commit)\`, Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
 
     planCommentWrapper=$(stripColors "${planCommentWrapper}")
     echo "plan: info: creating JSON"

--- a/src/terraform_taint.sh
+++ b/src/terraform_taint.sh
@@ -35,7 +35,7 @@ ${taintOutput}
 
 </details>
 
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+*Commit: \`$(pretty_git_commit)\`, Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
 
     taintCommentWrapper=$(stripColors "${taintCommentWrapper}")
     echo "taint: info: creating JSON"

--- a/src/terraform_validate.sh
+++ b/src/terraform_validate.sh
@@ -27,7 +27,7 @@ function terraformValidate {
 ${validateOutput}
 \`\`\`
 
-*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
+*Commit: \`$(pretty_git_commit)\`, Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Working Directory: \`${tfWorkingDir}\`, Workspace: \`${tfWorkspace}\`*"
 
     validateCommentWrapper=$(stripColors "${validateCommentWrapper}")
     echo "validate: info: creating JSON"


### PR DESCRIPTION
Reduces ambiguity where you push some commits, then push a few more, and
this action comments with a failure. What commit caused the failure?