### PR TITLE
Comment plan output correctly with -refresh=false (Do not use -{72} as plan start line)

### DIFF
--- a/src/terraform_plan.sh
+++ b/src/terraform_plan.sh
@@ -26,8 +26,9 @@ function terraformPlan {
     echo "plan: info: successfully planned Terraform configuration in ${tfWorkingDir}"
     echo "${planOutput}"
     echo
-    if echo "${planOutput}" | egrep '^-{72}$' &> /dev/null; then
-        planOutput=$(echo "${planOutput}" | sed -n -r '/-{72}/,/-{72}/{ /-{72}/d; p }')
+    planOutputMarker='An execution plan has been generated and is shown below\.'
+    if echo "${planOutput}" | egrep "^${planOutputMarker}$" &> /dev/null; then
+        planOutput=$(echo "${planOutput}" | sed -n -r "/^${planOutputMarker}$/,/-{72}/{ /-{72}/d; p}")
     fi
     planOutput=$(echo "${planOutput}" | sed -r -e 's/^  \+/\+/g' | sed -r -e 's/^  ~/~/g' | sed -r -e 's/^  -/-/g')
 


### PR DESCRIPTION
## Problem

### Prerequisites

.github/workflows/terraform.yml:
```
    - name: terraform plan
      uses: hashicorp/terraform-github-actions@master
      with:
        tf_actions_version: ${{ env.tf_version }}
        tf_actions_subcommand: 'plan'
        tf_actions_working_dir: ${{ matrix.working_directory }}
        tf_actions_comment: false
        args: '-refresh=false'
```

### Actual

The following is commented: 

```

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```

![image](https://user-images.githubusercontent.com/4200911/80352088-53cf4100-88ae-11ea-99b0-db9cabad0f90.png)


Plan output is not shown 🤔 

### Expected (example)

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_rds_cluster.main_any_dev will be updated in-place
  ~ resource "aws_rds_cluster" "main_any_dev" {
        apply_immediately                   = true
      ~ backup_retention_period             = 7 -> 8
      [...]
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Plan output is shown, and `Note: ` is not shown ✔️ 

## Why it occurs

plan of `-refresh=true`:
```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_iam_role.codebuild_database_definition: Refreshing state... [id=codebuild-smsdev1-database-definition]
[...]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_rds_cluster.main_any_dev will be updated in-place
  ~ resource "aws_rds_cluster" "main_any_dev" {
        apply_immediately                   = true
      ~ backup_retention_period             = 7 -> 8
      [...]
    }

Plan: 0 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

```


Plan output of `-refresh=false`:
```

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_rds_cluster.main_any_dev will be updated in-place
  ~ resource "aws_rds_cluster" "main_any_dev" {
        apply_immediately                   = true
      ~ backup_retention_period             = 7 -> 8
      [...]
    }

Plan: 0 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

```

https://github.com/hashicorp/terraform-github-actions/blob/875f1da8eaef201d5ede67352ddafbec8dd3e265/src/terraform_plan.sh#L30
This line removes output above `---...`.
With `-refresh=false` first `---...` is not shown, and finally whole plan output before bot comments.

## How do I fix

The root problem is using `-{72}` as a starter line of plan output.
`An execution plan has been generated and is shown below.`
